### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,14 +15,14 @@ DS1620	KEYWORD1
 read_temp	KEYWORD2
 write_th	KEYWORD2
 write_tl	KEYWORD2
-read_th 	KEYWORD2
-read_tl         KEYWORD2
-read_counter    KEYWORD2
-read_slope      KEYWORD2
-start_conv      KEYWORD2
-stop_conv       KEYWORD2
-write_config    KEYWORD2
-read_config     KEYWORD2
+read_th	KEYWORD2
+read_tl	KEYWORD2
+read_counter	KEYWORD2
+read_slope	KEYWORD2
+start_conv	KEYWORD2
+stop_conv	KEYWORD2
+write_config	KEYWORD2
+read_config	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords